### PR TITLE
Fix throttle double-call issue

### DIFF
--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -10,6 +10,10 @@ export function throttle<T extends (...args: any[]) => any>(
     const currentTime = performance.now(); // More precise than Date.now()
     
     if (currentTime - lastExecTime > delay) {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
       func(...args);
       lastExecTime = currentTime;
     } else {


### PR DESCRIPTION
## Summary
- clear pending timeout when throttling executes immediately

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.app.json` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6856628ce3dc832b9d67f08e989ae15a